### PR TITLE
Don't abort build on lint failures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,10 @@ android {
     dataBinding {
         enabled = true
     }
+    // Run lint checks, but without aborting on fail, for command line and CI builds
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Adds an option to the build.gradle so that the build won't fail on lint checks, since this seems to be a little finnicky, as CI builds or command line builds will fail while the Android Studio builds are fine.